### PR TITLE
Add the scale effect

### DIFF
--- a/src/RayTracer/RayTracer/Scene/Scene.cpp
+++ b/src/RayTracer/RayTracer/Scene/Scene.cpp
@@ -176,7 +176,7 @@ void RayTracer::Scene::makeRender(void)
             thread.join();
         }
     }
-    // _scale4();
+    // _scale(X4);
 }
 
 void RayTracer::Scene::exportToOutputFile(void)
@@ -421,48 +421,29 @@ Color RayTracer::Scene::_handleReflectColor(HitPrimitives hitPrimitives, std::si
     return newColor;
 }
 
-void RayTracer::Scene::_scale2()
+void RayTracer::Scene::_scale(RayTracer::Scene::ScaleFactor factor)
 {
     std::vector<std::vector<Color>> newPixels;
     std::vector<std::vector<Color>> tmpOutput;
     std::vector<Color> tmp;
+    std::size_t newSize = factor == X2 ? 2 : 3;
 
-    newPixels.resize(_pixels.size() * 2);
+    if (factor == X4) {
+        _scale(X2);
+        _scale(X2);
+        return;
+    }
+    newPixels.resize(_pixels.size() * newSize);
     for (std::size_t i = 0; i < _pixels.size(); i++) {
         for (std::size_t j = 0; j < _pixels[i].size(); j++) {
             tmpOutput = _getAroundColor(j, i);
-            std::vector<Color> scalePixels = _getScale2Color(tmpOutput);
-            for (std::size_t x = 0; x < 4; x++) {
-                newPixels[(i * 2) + (x / 2)].push_back(scalePixels[x]);
+            std::vector<Color> scalePixels = factor == X2 ? _getScale2Color(tmpOutput) : _getScale3Color(tmpOutput);
+            for (std::size_t x = 0; x < newSize * newSize; x++) {
+                newPixels[(i * newSize) + (x / newSize)].push_back(scalePixels[x]);
             }
         }
     }
     _pixels = newPixels;
-}
-
-void RayTracer::Scene::_scale3()
-{
-    std::vector<std::vector<Color>> newPixels;
-    std::vector<std::vector<Color>> tmpOutput;
-    std::vector<Color> tmp;
-
-    newPixels.resize(_pixels.size() * 3);
-    for (std::size_t i = 0; i < _pixels.size(); i++) {
-        for (std::size_t j = 0; j < _pixels[i].size(); j++) {
-            tmpOutput = _getAroundColor(j, i);
-            std::vector<Color> scalePixels = _getScale3Color(tmpOutput);
-            for (std::size_t x = 0; x < 9; x++) {
-                newPixels[(i * 3) + (x / 3)].push_back(scalePixels[x]);
-            }
-        }
-    }
-    _pixels = newPixels;
-}
-
-void RayTracer::Scene::_scale4()
-{
-    _scale2();
-    _scale2();
 }
 
 std::vector<std::vector<Color>> RayTracer::Scene::_getAroundColor(int i, int j)

--- a/src/RayTracer/RayTracer/Scene/Scene.cpp
+++ b/src/RayTracer/RayTracer/Scene/Scene.cpp
@@ -176,7 +176,7 @@ void RayTracer::Scene::makeRender(void)
             thread.join();
         }
     }
-    // _scale();
+    // _scale4();
 }
 
 void RayTracer::Scene::exportToOutputFile(void)
@@ -421,7 +421,7 @@ Color RayTracer::Scene::_handleReflectColor(HitPrimitives hitPrimitives, std::si
     return newColor;
 }
 
-void RayTracer::Scene::_scale()
+void RayTracer::Scene::_scale2()
 {
     std::vector<std::vector<Color>> newPixels;
     std::vector<std::vector<Color>> tmpOutput;
@@ -431,14 +431,38 @@ void RayTracer::Scene::_scale()
     for (std::size_t i = 0; i < _pixels.size(); i++) {
         for (std::size_t j = 0; j < _pixels[i].size(); j++) {
             tmpOutput = _getAroundColor(j, i);
-            std::vector<Color> scalePixels = _getScaleColor(tmpOutput);
-            newPixels[i * 2].push_back(scalePixels[0]);
-            newPixels[i * 2].push_back(scalePixels[1]);
-            newPixels[(i * 2) + 1].push_back(scalePixels[2]);
-            newPixels[(i * 2) + 1].push_back(scalePixels[3]);
+            std::vector<Color> scalePixels = _getScale2Color(tmpOutput);
+            for (std::size_t x = 0; x < 4; x++) {
+                newPixels[(i * 2) + (x / 2)].push_back(scalePixels[x]);
+            }
         }
     }
     _pixels = newPixels;
+}
+
+void RayTracer::Scene::_scale3()
+{
+    std::vector<std::vector<Color>> newPixels;
+    std::vector<std::vector<Color>> tmpOutput;
+    std::vector<Color> tmp;
+
+    newPixels.resize(_pixels.size() * 3);
+    for (std::size_t i = 0; i < _pixels.size(); i++) {
+        for (std::size_t j = 0; j < _pixels[i].size(); j++) {
+            tmpOutput = _getAroundColor(j, i);
+            std::vector<Color> scalePixels = _getScale3Color(tmpOutput);
+            for (std::size_t x = 0; x < 9; x++) {
+                newPixels[(i * 3) + (x / 3)].push_back(scalePixels[x]);
+            }
+        }
+    }
+    _pixels = newPixels;
+}
+
+void RayTracer::Scene::_scale4()
+{
+    _scale2();
+    _scale2();
 }
 
 std::vector<std::vector<Color>> RayTracer::Scene::_getAroundColor(int i, int j)
@@ -462,16 +486,56 @@ std::vector<std::vector<Color>> RayTracer::Scene::_getAroundColor(int i, int j)
     return output;
 }
 
-std::vector<Color> RayTracer::Scene::_getScaleColor(std::vector<std::vector<Color>> colors)
+std::vector<Color> RayTracer::Scene::_getScale2Color(std::vector<std::vector<Color>> colors)
 {
-    if (colors[0][1] != colors[2][1] && colors[1][0] != colors[1][2]) {
+    Color B = colors[0][1];
+    Color D = colors[1][0];
+    Color E = colors[1][1];
+    Color F = colors[1][2];
+    Color H = colors[2][1];
+
+    if (B != H && D != F) {
         return {
-            colors[1][0] == colors[0][1] ? colors[1][0] : colors[1][1],
-            colors[0][1] == colors[1][2] ? colors[1][2] : colors[1][1],
-            colors[1][0] == colors[2][1] ? colors[2][1] : colors[1][1],
-            colors[2][1] == colors[1][2] ? colors[1][2] : colors[1][1],
+            D == B ? D : E,
+            B == F ? F : E,
+            D == H ? D : E,
+            H == F ? F : E,
         };
     } else {
-        return {colors[1][1], colors[1][1], colors[1][1], colors[1][1]};
+        return {
+            E,
+            E,
+            E,
+            E,
+        };
+    }
+}
+
+std::vector<Color> RayTracer::Scene::_getScale3Color(std::vector<std::vector<Color>> colors)
+{
+    Color A = colors[0][0];
+    Color B = colors[0][1];
+    Color C = colors[0][2];
+    Color D = colors[1][0];
+    Color E = colors[1][1];
+    Color F = colors[1][2];
+    Color G = colors[2][0];
+    Color H = colors[2][1];
+    Color I = colors[2][2];
+
+    if (B != H && D != F) {
+        return {
+            D == B ? D : E,
+            (D == B && E != C) || (B == F && E != A) ? B : E,
+            B == F ? F : E,
+            (D == B && E != G) || (D == H && E != A) ? D : E,
+            E,
+            (B == F && E != I) || (H == F && E != C) ? F : E,
+            D == H ? D : E,
+            (D == H && E != I) || (H == F && E != G) ? H : E,
+            H == F ? F : E,
+        };
+    } else {
+        return {E, E, E, E, E, E, E, E, E};
     }
 }

--- a/src/RayTracer/RayTracer/Scene/Scene.cpp
+++ b/src/RayTracer/RayTracer/Scene/Scene.cpp
@@ -176,6 +176,7 @@ void RayTracer::Scene::makeRender(void)
             thread.join();
         }
     }
+    // _scale();
 }
 
 void RayTracer::Scene::exportToOutputFile(void)
@@ -418,4 +419,59 @@ Color RayTracer::Scene::_handleReflectColor(HitPrimitives hitPrimitives, std::si
         std::get<3>(color)
     };
     return newColor;
+}
+
+void RayTracer::Scene::_scale()
+{
+    std::vector<std::vector<Color>> newPixels;
+    std::vector<std::vector<Color>> tmpOutput;
+    std::vector<Color> tmp;
+
+    newPixels.resize(_pixels.size() * 2);
+    for (std::size_t i = 0; i < _pixels.size(); i++) {
+        for (std::size_t j = 0; j < _pixels[i].size(); j++) {
+            tmpOutput = _getAroundColor(j, i);
+            std::vector<Color> scalePixels = _getScaleColor(tmpOutput);
+            newPixels[i * 2].push_back(scalePixels[0]);
+            newPixels[i * 2].push_back(scalePixels[1]);
+            newPixels[(i * 2) + 1].push_back(scalePixels[2]);
+            newPixels[(i * 2) + 1].push_back(scalePixels[3]);
+        }
+    }
+    _pixels = newPixels;
+}
+
+std::vector<std::vector<Color>> RayTracer::Scene::_getAroundColor(int i, int j)
+{
+    std::vector<std::vector<Color>> output;
+
+    output.resize(3);
+    for (int x = -1; x < 2; x++) {
+        if (j + x < 0 || j + x >= static_cast<int>(_pixels.size())) {
+            output[x + 1] = {{0, 0, 0, 255}, {0, 0, 0, 255}, {0, 0, 0, 255}};
+            continue;
+        }
+        for (int y = -1; y < 2; y++) {
+            if (i + y < 0 || i + y >= static_cast<int>(_pixels[j + x].size())) {
+                output[x + 1].push_back({0, 0, 0, 255});
+            } else {
+                output[x + 1].push_back(_pixels[j + x][i + y]);
+            }
+        }
+    }
+    return output;
+}
+
+std::vector<Color> RayTracer::Scene::_getScaleColor(std::vector<std::vector<Color>> colors)
+{
+    if (colors[0][1] != colors[2][1] && colors[1][0] != colors[1][2]) {
+        return {
+            colors[1][0] == colors[0][1] ? colors[1][0] : colors[1][1],
+            colors[0][1] == colors[1][2] ? colors[1][2] : colors[1][1],
+            colors[1][0] == colors[2][1] ? colors[2][1] : colors[1][1],
+            colors[2][1] == colors[1][2] ? colors[1][2] : colors[1][1],
+        };
+    } else {
+        return {colors[1][1], colors[1][1], colors[1][1], colors[1][1]};
+    }
 }

--- a/src/RayTracer/RayTracer/Scene/Scene.hh
+++ b/src/RayTracer/RayTracer/Scene/Scene.hh
@@ -69,8 +69,11 @@ namespace RayTracer
             Color _getPrimitiveColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray, std::size_t depth = 0);
             Color _handleFlatColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray);
             Color _handleReflectColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray, std::size_t depth = 0);
-            void _scale();
+            void _scale2();
+            void _scale3();
+            void _scale4();
             std::vector<std::vector<Color>> _getAroundColor(int i, int j);
-            std::vector<Color> _getScaleColor(std::vector<std::vector<Color>> colors);
+            std::vector<Color> _getScale2Color(std::vector<std::vector<Color>> colors);
+            std::vector<Color> _getScale3Color(std::vector<std::vector<Color>> colors);
     };
 }

--- a/src/RayTracer/RayTracer/Scene/Scene.hh
+++ b/src/RayTracer/RayTracer/Scene/Scene.hh
@@ -42,6 +42,12 @@ namespace RayTracer
                 RIGHT_ANGLE,
             };
 
+            enum ScaleFactor {
+                X2,
+                X3,
+                X4,
+            };
+
             std::vector<std::vector<Color>> getPixels(void) const;
 
             void setPixels(std::vector<std::vector<Color>> pixels);
@@ -69,9 +75,7 @@ namespace RayTracer
             Color _getPrimitiveColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray, std::size_t depth = 0);
             Color _handleFlatColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray);
             Color _handleReflectColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray, std::size_t depth = 0);
-            void _scale2();
-            void _scale3();
-            void _scale4();
+            void _scale(ScaleFactor factor);
             std::vector<std::vector<Color>> _getAroundColor(int i, int j);
             std::vector<Color> _getScale2Color(std::vector<std::vector<Color>> colors);
             std::vector<Color> _getScale3Color(std::vector<std::vector<Color>> colors);

--- a/src/RayTracer/RayTracer/Scene/Scene.hh
+++ b/src/RayTracer/RayTracer/Scene/Scene.hh
@@ -69,5 +69,8 @@ namespace RayTracer
             Color _getPrimitiveColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray, std::size_t depth = 0);
             Color _handleFlatColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray);
             Color _handleReflectColor(HitPrimitives hitPrimitives, std::size_t index, RayTracer::Ray ray, std::size_t depth = 0);
+            void _scale();
+            std::vector<std::vector<Color>> _getAroundColor(int i, int j);
+            std::vector<Color> _getScaleColor(std::vector<std::vector<Color>> colors);
     };
 }


### PR DESCRIPTION
Add the scale effect methods, currently the scale is not used in the scene, it's in comment in the `makeRender` method, it will be changed when the configuration file will be finished

### Scene
- Add the `_scale2` `_scale3` and `_scale4` methods to scale the pixels
- Add the `_getAroundColor` method to get the pixels and its neighbors
- Add the `_getScale2Color` and `_getScale3Color` to get the result of the scale effect